### PR TITLE
Add iOS SwiftUI wrapper and scraping workflow for Carnaval der Dieren

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,39 @@ options:
 *   **Student's View Rotation**: The "Student's View" is a 180-degree rotation of the "Teacher's View". This means:
     *   The table block that is at the "front" in the Teacher's View (e.g., Table 1) will appear as the "back" table from the student's perspective.
     *   Seats are mirrored accordingly. For example, the student in the top-left seat of Table 1 (Teacher's View) would appear in the bottom-right seat of the corresponding (now rearmost) table in the Student's View.
+
+## iPhone Wrapper App (Carnaval der Dieren)
+
+This repository now includes an iOS wrapper app at:
+
+- `ios/CarnavalDerDierenApp`
+
+### What it does
+
+- Loads a locally scraped copy of the app from `WebMirror/index.html` if present.
+- Falls back to the live URL `https://followamuse.nl/apps/carnaval-der-dieren/` when no local mirror exists.
+
+### Scrape the web app
+
+Use:
+
+```bash
+./scripts/scrape_followamuse.sh
+```
+
+This mirrors the page assets into:
+
+- `ios/CarnavalDerDierenApp/CarnavalDerDierenApp/Resources/WebMirror`
+
+### Generate and run the Xcode project
+
+1. Install `xcodegen` if needed (`brew install xcodegen`).
+2. Generate project files:
+
+```bash
+cd ios/CarnavalDerDierenApp
+xcodegen generate
+```
+
+3. Open `CarnavalDerDierenApp.xcodeproj` in Xcode.
+4. Build/run on an iPhone simulator or a physical iPhone.

--- a/ios/CarnavalDerDierenApp/CarnavalDerDierenApp/AppWebView.swift
+++ b/ios/CarnavalDerDierenApp/CarnavalDerDierenApp/AppWebView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+import WebKit
+
+struct AppWebView: UIViewRepresentable {
+    func makeUIView(context: Context) -> WKWebView {
+        let webView = WKWebView(frame: .zero)
+        webView.scrollView.bounces = false
+
+        if let localIndex = Bundle.main.url(forResource: "index", withExtension: "html", subdirectory: "WebMirror") {
+            webView.loadFileURL(localIndex, allowingReadAccessTo: localIndex.deletingLastPathComponent())
+        } else if let remoteURL = URL(string: "https://followamuse.nl/apps/carnaval-der-dieren/") {
+            webView.load(URLRequest(url: remoteURL))
+        }
+
+        return webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+    }
+}

--- a/ios/CarnavalDerDierenApp/CarnavalDerDierenApp/CarnavalDerDierenApp.swift
+++ b/ios/CarnavalDerDierenApp/CarnavalDerDierenApp/CarnavalDerDierenApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct CarnavalDerDierenApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/ios/CarnavalDerDierenApp/CarnavalDerDierenApp/ContentView.swift
+++ b/ios/CarnavalDerDierenApp/CarnavalDerDierenApp/ContentView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        AppWebView()
+            .ignoresSafeArea()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/ios/CarnavalDerDierenApp/CarnavalDerDierenApp/Info.plist
+++ b/ios/CarnavalDerDierenApp/CarnavalDerDierenApp/Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+</dict>
+</plist>

--- a/ios/CarnavalDerDierenApp/CarnavalDerDierenApp/Resources/WebMirror.README.md
+++ b/ios/CarnavalDerDierenApp/CarnavalDerDierenApp/Resources/WebMirror.README.md
@@ -1,0 +1,10 @@
+# WebMirror
+
+Place the scraped web app here.
+
+Expected entrypoint path:
+
+- `WebMirror/index.html`
+
+The iOS app will load this local entrypoint if available.
+If it is missing, the app falls back to the live URL.

--- a/ios/CarnavalDerDierenApp/project.yml
+++ b/ios/CarnavalDerDierenApp/project.yml
@@ -1,0 +1,28 @@
+name: CarnavalDerDierenApp
+options:
+  minimumXcodeGenVersion: 2.38.0
+  deploymentTarget:
+    iOS: 16.0
+settings:
+  base:
+    PRODUCT_BUNDLE_IDENTIFIER: nl.followamuse.carnavalderdieren
+    SWIFT_VERSION: 5.0
+targets:
+  CarnavalDerDierenApp:
+    type: application
+    platform: iOS
+    sources:
+      - path: CarnavalDerDierenApp
+    resources:
+      - path: CarnavalDerDierenApp/Resources
+    settings:
+      base:
+        INFOPLIST_FILE: CarnavalDerDierenApp/Info.plist
+        PRODUCT_NAME: Carnaval der Dieren
+    info:
+      path: CarnavalDerDierenApp/Info.plist
+      properties:
+        CFBundleDisplayName: Carnaval der Dieren
+        UILaunchScreen: {}
+        UIApplicationSceneManifest:
+          UIApplicationSupportsMultipleScenes: false

--- a/scripts/scrape_followamuse.sh
+++ b/scripts/scrape_followamuse.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+URL="https://followamuse.nl/apps/carnaval-der-dieren/"
+DEST="ios/CarnavalDerDierenApp/CarnavalDerDierenApp/Resources/WebMirror"
+
+rm -rf "$DEST"
+mkdir -p "$DEST"
+
+wget \
+  --mirror \
+  --convert-links \
+  --adjust-extension \
+  --page-requisites \
+  --no-parent \
+  --directory-prefix "$DEST" \
+  "$URL"
+
+# Flatten first downloaded html page to index.html in WebMirror root.
+FIRST_HTML=$(find "$DEST" -name '*.html' | head -n 1)
+if [[ -n "${FIRST_HTML:-}" ]]; then
+  cp "$FIRST_HTML" "$DEST/index.html"
+fi
+
+echo "Scraped app into: $DEST"


### PR DESCRIPTION
### Motivation
- Provide an iPhone-ready wrapper for the web app so the experience can be run as a native iOS app and also be bundled for offline use.
- Enable a reproducible scraping workflow that mirrors the web app into the app bundle so the app can load local assets instead of depending on the live site.

### Description
- Add an XcodeGen-based iOS SwiftUI scaffold under `ios/CarnavalDerDierenApp` including `Info.plist`, `project.yml`, app entry (`@main`), and `ContentView` to host the UI.
- Implement `AppWebView` using `WKWebView` that first tries to load `WebMirror/index.html` from the app bundle and falls back to `https://followamuse.nl/apps/carnaval-der-dieren/` if no local mirror is present.
- Add `scripts/scrape_followamuse.sh` which uses `wget` to mirror the site into `ios/CarnavalDerDierenApp/CarnavalDerDierenApp/Resources/WebMirror` and normalizes the first HTML into `index.html`.
- Update `README.md` and add `WebMirror.README.md` documenting how to run the scraper, generate the Xcode project with `xcodegen`, and run the app in simulator or on device.

### Testing
- Ran shell syntax check `bash -n scripts/scrape_followamuse.sh`, which passed successfully.
- Attempted to run `./scripts/scrape_followamuse.sh`, which failed in this environment due to proxy/SSL restrictions preventing access to `followamuse.nl` (network access failure), so no local mirror was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbea29b4848323bdafff5d4772514d)